### PR TITLE
Add missing deps for openbabel.pybel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,8 @@ free-threaded-support = true
 [tool.cibuildwheel.linux]
 # refer rdkit-pypi
 before-all = [
+    # Openbabel.pybel has dependency on these x11 dev libraries
+    "yum install -y libXext-devel libXrender-devel",
     # Has eigen3-devel.aarch64
     "yum install -y epel-release",
     "yum install -y wget freetype-devel libpng12-devel pixman-devel zlib-devel libxml2-devel",


### PR DESCRIPTION
Otherwise importing `openbabel.pybel` errors as per the following minimal example:
```
FROM python:slim
RUN pip install openbabel-wheel
# Final line fails; uncomment next line to fix
# RUN apt-get -q update && apt-get install -y --no-install-recommends libxext-dev libxrender-dev
RUN python -c "from openbabel import pybel"
```
which gives:
```
Error: libXrender.so.1: cannot open shared object file: No such file or directory
```
and
```
 Error: libXext.so.6: cannot open shared object file: No such file or directory
```